### PR TITLE
enable multi-statement execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Contributions are very welcome, as are feature requests and suggestions. Please 
 [docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg
 [docs-stable-url]: https://JuliaData.github.io/MySQL.jl/stable
 
-[travis-img]: https://travis-ci.org/JuliaData/MySQL.jl.svg?branch=master
-[travis-url]: https://travis-ci.org/JuliaData/MySQL.jl
+[travis-img]: https://travis-ci.org/JuliaDatabases/MySQL.jl.svg?branch=master
+[travis-url]: https://travis-ci.org/JuliaDatabases/MySQL.jl
 
-[codecov-img]: https://codecov.io/gh/JuliaData/MySQL.jl/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/JuliaData/MySQL.jl
+[codecov-img]: https://codecov.io/gh/JuliaDatabases/MySQL.jl/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/JuliaDatabases/MySQL.jl
 
-[issues-url]: https://github.com/JuliaData/MySQL.jl/issues
+[issues-url]: https://github.com/JuliaDatabases/MySQL.jl/issues
 
 [pkg-0.6-img]: http://pkg.julialang.org/badges/MySQL_0.6.svg
 [pkg-0.6-url]: http://pkg.julialang.org/?pkg=MySQL

--- a/src/MySQL.jl
+++ b/src/MySQL.jl
@@ -91,8 +91,14 @@ execute an sql statement without returning results (useful for DDL statements, u
 """
 function execute!(conn::Connection, sql::String)
     conn.ptr == C_NULL && throw(MySQLInterfaceError("`MySQL.execute!` called with NULL connection."))
-    API.mysql_query(conn.ptr, sql) == 0 || throw(MySQLInternalError(conn))
-    return Int(API.mysql_affected_rows(conn.ptr))
+    status = API.mysql_query(conn.ptr, sql)
+    status == 0 || throw(MySQLInternalError(conn))
+    res = 0
+    while status == 0
+        res += Int(API.mysql_affected_rows(conn.ptr))
+        status = API.mysql_next_result(conn.ptr)
+    end
+    return res
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,3 +107,15 @@ Data.stream!(values, stmt)
 res = MySQL.query(conn, "select * from Employee")
 @test length(res) == 10
 @test length(res[1]) == 9
+
+# test multi-statement execution
+MySQL.execute!(conn, """DROP DATABASE if exists mysqltest2;
+    CREATE DATABASE mysqltest2;
+    USE mysqltest2;
+    CREATE TABLE test (a varchar(20), b integer);
+    INSERT INTO test (a,b) value ("test",123);""")
+
+res = MySQL.query(conn, """select * from test;""")
+
+@test res.a[1] == "test"
+@test res.b[1] == 123


### PR DESCRIPTION
Adds while loop to MySQL.execute! to enable multi-statement execution. This functionality is already enabled via the client_flag, but is not working (see [Issue 104](https://github.com/JuliaDatabases/MySQL.jl/issues/104)).

This implements the solution from the [MySQL C API docs](https://dev.mysql.com/doc/refman/8.0/en/c-api-multiple-queries.html), but assumes that only non-returning statements are being executed.  This is consistent with the current implementation and the docs.