### PR TITLE
Fix calling stored procedures that return resultsets

### DIFF
--- a/src/MySQL.jl
+++ b/src/MySQL.jl
@@ -47,7 +47,7 @@ end
 
 function clear!(conn, result::API.MYSQL_RES)
     if result.ptr != C_NULL
-        while API.fetchrow(conn.mysql, result) != C_NULL
+        while API.fetchrow(conn.mysql, result) != C_NULL || API.nextresult(conn.mysql) !== nothing
         end
         finalize(result)
     end
@@ -56,7 +56,7 @@ end
 
 function clear!(conn, stmt::API.MYSQL_STMT)
     if stmt.ptr != C_NULL
-        while API.fetch(stmt) == 0
+        while API.fetch(stmt) == 0 || API.nextresult(stmt) !== nothing
         end
     end
     return

--- a/src/api/capi.jl
+++ b/src/api/capi.jl
@@ -662,7 +662,7 @@ Return Value	Description
 """=#
 function nextresult(mysql::MYSQL)
     ret = mysql_next_result(mysql.ptr)
-    return ret == -1 ? nothing : reg == 0 ? ret : throw(Error(mysql))
+    return ret == -1 ? nothing : ret == 0 ? ret : throw(Error(mysql))
 end
 
 #="""

--- a/src/api/papi.jl
+++ b/src/api/papi.jl
@@ -272,7 +272,8 @@ Return Value	Description
 
 """
 function nextresult(stmt::MYSQL_STMT)
-    return mysql_stmt_next_result(stmt.ptr)
+    ret = mysql_stmt_next_result(stmt.ptr)
+    return ret == -1 ? nothing : ret == 0 ? ret : throw(StmtError(stmt))
 end
 
 """

--- a/src/execute.jl
+++ b/src/execute.jl
@@ -91,8 +91,14 @@ function Base.iterate(cursor::TextCursor{buffered}, i=1) where {buffered}
     rowptr = API.fetchrow(cursor.conn.mysql, cursor.result)
     if rowptr == C_NULL
         !buffered && API.errno(cursor.conn.mysql) != 0 && throw(API.Error(cursor.conn.mysql))
-        finalize(cursor.result)
-        return nothing
+        if API.nextresult(cursor.conn.mysql) === nothing
+            finalize(cursor.result)
+            return nothing
+        else
+            # we ***ignore*** additional resultsets for now
+            clear!(cursor.conn)
+            return nothing
+        end
     end
     lengths = API.fetchlengths(cursor.result, cursor.nfields)
     cursor.current_rownumber = i

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -221,3 +221,31 @@ DBInterface.execute(stmt, [-1, "hey there sailor"])
 res = DBInterface.execute(conn, "select id, t from blob_field") |> columntable
 @test length(res) == 2
 @test res[2][1] == [0x68, 0x65, 0x79, 0x20, 0x74, 0x68, 0x65, 0x72, 0x65, 0x20, 0x73, 0x61, 0x69, 0x6c, 0x6f, 0x72]
+
+
+DBInterface.execute(conn, """
+CREATE PROCEDURE get_employee()
+BEGIN
+   select * from Employee;
+END
+""")
+res = DBInterface.execute(conn, "call get_employee()") |> columntable
+@test length(res) > 0
+@test length(res[1]) == 5
+res = DBInterface.execute(conn, "call get_employee()") |> columntable
+@test length(res) > 0
+@test length(res[1]) == 5
+# test that we can call multiple stored procedures in a row w/o collecting results (they get cleaned up properly internally)
+res = DBInterface.execute(conn, "call get_employee()")
+res = DBInterface.execute(conn, "call get_employee()")
+
+# and for prepared statements
+stmt = DBInterface.prepare(conn, "call get_employee()")
+res = DBInterface.execute(stmt) |> columntable
+@test length(res) > 0
+@test length(res[1]) == 5
+res = DBInterface.execute(stmt) |> columntable
+@test length(res) > 0
+@test length(res[1]) == 5
+res = DBInterface.execute(stmt)
+res = DBInterface.execute(stmt)


### PR DESCRIPTION
Fixes #149.

The issue here is that calling stored procedures that return resultsets
return the resultset, and then an extra, empty resultset (who knows why,
but whatever). In general, we weren't handling when queries returned
multiple resultsets anyway, so this was a more general problem. We now
will return the first resultset as the official resultset and clear out
any additional resultsets if they exist. We should definitely come up
with a better api if people actually need/want multiple resultsets, but
that's a problem for another day.

It turns out we also had problems returning resultsets from prepared
statements, which is the reason for the extra tests and code changes in
prepare.jl.