### PR TITLE
Implement new `DBInterface.executemultiple` interface function

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -249,3 +249,22 @@ res = DBInterface.execute(stmt) |> columntable
 @test length(res[1]) == 5
 res = DBInterface.execute(stmt)
 res = DBInterface.execute(stmt)
+
+results = DBInterface.executemultiple(conn, "select * from Employee; select DeptNo, OfficeNo from Employee where OfficeNo IS NOT NULL")
+state = iterate(results)
+@test state !== nothing
+res, st = state
+@test !st
+@test length(res) == 5
+ret = columntable(res)
+@test length(ret[1]) == 5
+state = iterate(results, st)
+@test state !== nothing
+res, st = state
+@test !st
+@test length(res) == 4
+ret = columntable(res)
+@test length(ret[1]) == 4
+
+# multiple-queries not supported by mysql w/ prepared statements
+@test_throws MySQL.API.StmtError DBInterface.prepare(conn, "select * from Employee; select DeptNo, OfficeNo from Employee where OfficeNo IS NOT NULL")


### PR DESCRIPTION
This allows returning multiple resultsets from a single query call; this
requires setting `multi_statements` to `true` by default, but I couldn't
think of any downside to doing this (vs. the alternative in which a user
finds the function, tries it and immediately fails and has to restart
their connection by setting the flag). Prepared statements don't support
multiple resultsets, and an error is thrown appropriately (from mysql
itself). This PR requires
https://github.com/JuliaDatabases/DBInterface.jl/pull/26 to be merged
and tagged first.