### PR TITLE
Don't call unsigned(T) for T <: AbstractFloat

### DIFF
--- a/src/MySQL.jl
+++ b/src/MySQL.jl
@@ -302,7 +302,7 @@ Base.isopen(conn::Connection) = API.isopen(conn.mysql)
 
 function juliatype(field_type, notnullable, isunsigned, isbinary)
     T = API.juliatype(field_type)
-    T2 = isunsigned ? unsigned(T) : T
+    T2 = isunsigned && !(T <: AbstractFloat) ? unsigned(T) : T
     T3 = !isbinary && T2 == Vector{UInt8} ? String : T2
     return notnullable ? T3 : Union{Missing, T3}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -279,6 +279,18 @@ ret = columntable(res)
 # multiple-queries not supported by mysql w/ prepared statements
 @test_throws MySQL.API.StmtError DBInterface.prepare(conn, "select * from Employee; select DeptNo, OfficeNo from Employee where OfficeNo IS NOT NULL")
 
+# GitHub issue [#173](https://github.com/JuliaDatabases/MySQL.jl/issues/173)
+DBInterface.execute(conn, "DROP TABLE if exists unsigned_float")
+DBInterface.execute(conn, "CREATE TABLE unsigned_float(x FLOAT unsigned)")
+stmt = DBInterface.prepare(conn, "INSERT INTO unsigned_float VALUES (?)")
+for val in [1.1, 1.2]
+    DBInterface.execute(stmt, val)
+end
+res = DBInterface.execute(conn, "select x from unsigned_float")
+@test length(res) == 2
+@test res[1][1] === 1.1
+# end issue #173
+
 # 156
 res = DBInterface.execute(conn, "select * from Employee")
 DBInterface.close!(conn)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -282,13 +282,9 @@ ret = columntable(res)
 # GitHub issue [#173](https://github.com/JuliaDatabases/MySQL.jl/issues/173)
 DBInterface.execute(conn, "DROP TABLE if exists unsigned_float")
 DBInterface.execute(conn, "CREATE TABLE unsigned_float(x FLOAT unsigned)")
-stmt = DBInterface.prepare(conn, "INSERT INTO unsigned_float VALUES (?)")
-for val in [1.1, 1.2]
-    DBInterface.execute(stmt, val)
-end
-res = DBInterface.execute(conn, "select x from unsigned_float")
-@test length(res) == 2
-@test res[1][1] === 1.1
+DBInterface.execute(conn, "INSERT INTO unsigned_float VALUES (1.1), (1.2)")
+res = DBInterface.execute(conn, "select x from unsigned_float") |> columntable
+@test res.x == Vector{Float32}([1.1, 1.2])
 # end issue #173
 
 # 156


### PR DESCRIPTION
This PR fixes an issue with unsigned float columns.

Fixes #173 