### PR TITLE
Improve handing of DateTime values for 1970-01-01

### DIFF
--- a/src/api/apitypes.jl
+++ b/src/api/apitypes.jl
@@ -135,15 +135,9 @@ Base.convert(::Type{MYSQL_TIME}, t::Dates.Time) =
 Base.convert(::Type{MYSQL_TIME}, dt::Date) =
     MYSQL_TIME(Dates.year(dt), Dates.month(dt), Dates.day(dt), 0, 0, 0, 0, 0, 0)
 
-function Base.convert(::Type{MYSQL_TIME}, dtime::DateTime)
-    if Dates.year(dtime) == 1970 && Dates.month(dtime) == 1 && Dates.day(dtime) == 1
-        MYSQL_TIME(0, 0, 0,
-                   Dates.hour(dtime), Dates.minute(dtime), Dates.second(dtime), 0, 0, 0)
-    else
-        MYSQL_TIME(Dates.year(dtime), Dates.month(dtime), Dates.day(dtime),
-                   Dates.hour(dtime), Dates.minute(dtime), Dates.second(dtime), 0, 0, 0)
-    end
-end
+Base.convert(::Type{MYSQL_TIME}, dtime::DateTime) =
+    MYSQL_TIME(Dates.year(dtime), Dates.month(dtime), Dates.day(dtime),
+               Dates.hour(dtime), Dates.minute(dtime), Dates.second(dtime), 0, 0, 0)
 
 # this is a helper struct, because MYSQL_BIND needs
 # to know where the bound data should live, by using this helper

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -232,6 +232,15 @@ res = DBInterface.execute(conn, "select id, t from blob_field") |> columntable
 @test length(res) == 2
 @test res[2][1] == [0x68, 0x65, 0x79, 0x20, 0x74, 0x68, 0x65, 0x72, 0x65, 0x20, 0x73, 0x61, 0x69, 0x6c, 0x6f, 0x72]
 
+# https://github.com/JuliaDatabases/MySQL.jl/issues/175
+DBInterface.execute(conn, "DROP TABLE if exists datetime_field")
+DBInterface.execute(conn, "CREATE TABLE datetime_field (id int(11), t DATETIME)")
+stmt = DBInterface.prepare(conn, "INSERT INTO datetime_field (id, t) VALUES (?, ?);")
+DBInterface.execute(stmt, [1, DateTime(1970, 1, 1, 3)])
+resstmt = DBInterface.prepare(conn, "select id, t from datetime_field")
+res = DBInterface.execute(resstmt) |> columntable
+@test length(res) == 2
+@test res[2][1] == DateTime(1970, 1, 1, 3)
 
 DBInterface.execute(conn, """
 CREATE PROCEDURE get_employee()


### PR DESCRIPTION
Fixes #175. As @david-macmahon pointed out, it was a bit strange that we
were special-casing the binding of MYSQL_TIME structs when converting
from DateTime. The mysql DATETIME type specifically supports dates
between 1000-01-01 to 9999-12-31 23:59:59, so there's no reason we
should be special-casing 1970-01-01.