### PR TITLE
Introduce a new DateAndTime sturct for > millisecond precision support

### DIFF
--- a/src/MySQL.jl
+++ b/src/MySQL.jl
@@ -2,7 +2,7 @@ module MySQL
 
 using Dates, DBInterface, Tables, Parsers, DecFP
 
-export DBInterface
+export DBInterface, DateAndTime
 
 # For non-C-api errors that happen in MySQL.jl
 struct MySQLInterfaceError
@@ -300,11 +300,12 @@ end
 Base.close(conn::Connection) = DBInterface.close!(conn)
 Base.isopen(conn::Connection) = API.isopen(conn.mysql)
 
-function juliatype(field_type, notnullable, isunsigned, isbinary)
+function juliatype(field_type, notnullable, isunsigned, isbinary, date_and_time)
     T = API.juliatype(field_type)
     T2 = isunsigned && !(T <: AbstractFloat) ? unsigned(T) : T
     T3 = !isbinary && T2 == Vector{UInt8} ? String : T2
-    return notnullable ? T3 : Union{Missing, T3}
+    T4 = date_and_time && T3 <: DateTime ? DateAndTime : T3
+    return notnullable ? T4 : Union{Missing, T4}
 end
 
 include("execute.jl")

--- a/src/api/API.jl
+++ b/src/api/API.jl
@@ -2,6 +2,8 @@ module API
 
 using Dates, DecFP
 
+export DateAndTime
+
 if VERSION < v"1.3.0"
 
 # Load libmariadb from our deps.jl

--- a/src/api/consts.jl
+++ b/src/api/consts.jl
@@ -48,6 +48,25 @@ end
 Base.show(io::IO, b::Bit) = print(io, "MySQL.API.Bit(\"$(string(b))\")")
 Base.unsigned(::Type{Bit}) = Bit
 
+struct DateAndTime <: Dates.AbstractDateTime
+    date::Date
+    time::Time
+end
+
+Dates.Date(x::DateAndTime) = x.date
+Dates.Time(x::DateAndTime) = x.time
+Dates.year(x::DateAndTime) = Dates.year(Date(x))
+Dates.month(x::DateAndTime) = Dates.month(Date(x))
+Dates.day(x::DateAndTime) = Dates.day(Date(x))
+Dates.hour(x::DateAndTime) = Dates.hour(Time(x))
+Dates.minute(x::DateAndTime) = Dates.minute(Time(x))
+Dates.second(x::DateAndTime) = Dates.second(Time(x))
+Dates.millisecond(x::DateAndTime) = Dates.millisecond(Time(x))
+Dates.microsecond(x::DateAndTime) = Dates.microsecond(Time(x))
+
+import Base.==
+==(a::DateAndTime, b::DateAndTime) = ==(a.date, b.date) && ==(a.time, b.time)
+
 mysqltype(::Type{Bit}) = MYSQL_TYPE_BIT
 mysqltype(::Union{Type{Cchar}, Type{Cuchar}}) = MYSQL_TYPE_TINY
 mysqltype(::Union{Type{Cshort}, Type{Cushort}}) = MYSQL_TYPE_SHORT
@@ -58,6 +77,7 @@ mysqltype(::Type{Dec64}) = MYSQL_TYPE_DECIMAL
 mysqltype(::Type{Cdouble}) = MYSQL_TYPE_DOUBLE
 mysqltype(::Type{Vector{UInt8}}) = MYSQL_TYPE_BLOB
 mysqltype(::Type{DateTime}) = MYSQL_TYPE_TIMESTAMP
+mysqltype(::Type{DateAndTime}) = MYSQL_TYPE_DATETIME
 mysqltype(::Type{Date}) = MYSQL_TYPE_DATE
 mysqltype(::Type{Time}) = MYSQL_TYPE_TIME
 mysqltype(::Type{Missing}) = MYSQL_TYPE_NULL

--- a/src/load.jl
+++ b/src/load.jl
@@ -29,6 +29,7 @@ const SQLTYPES = Dict{Type, String}(
     Date => "DATE",
     Time => "TIME",
     DateTime => "DATETIME",
+    DateAndTime => "DATETIME(6)",
 )
 
 checkdupnames(names) = length(unique(map(x->lowercase(String(x)), names))) == length(names) || error("duplicate case-insensitive column names detected; sqlite doesn't allow duplicate column names and treats them case insensitive")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -242,6 +242,19 @@ res = DBInterface.execute(resstmt) |> columntable
 @test length(res) == 2
 @test res[2][1] == DateTime(1970, 1, 1, 3)
 
+# https://github.com/JuliaDatabases/MySQL.jl/issues/165
+DBInterface.execute(conn, "DROP TABLE if exists datetime6_field")
+DBInterface.execute(conn, "CREATE TABLE datetime6_field (id int(11), t DATETIME(6))")
+stmt = DBInterface.prepare(conn, "INSERT INTO datetime6_field (id, t) VALUES (?, ?);")
+DBInterface.execute(stmt, [1, DateAndTime(Date(2021, 1, 2), Time(1, 2, 3, 456, 789))])
+resstmt = DBInterface.prepare(conn, "select id, t from datetime6_field"; mysql_date_and_time=true)
+res = DBInterface.execute(resstmt) |> columntable
+@test length(res) == 2
+@test res[2][1] == DateAndTime(Date(2021, 1, 2), Time(1, 2, 3, 456, 789))
+res = DBInterface.execute(conn, "select id, t from datetime6_field"; mysql_date_and_time=true) |> columntable
+@test length(res) == 2
+@test res[2][1] == DateAndTime(Date(2021, 1, 2), Time(1, 2, 3, 456, 789))
+
 DBInterface.execute(conn, """
 CREATE PROCEDURE get_employee()
 BEGIN


### PR DESCRIPTION
Fixes #165 (and #172). So the proposal here is a bit tricky, but here's
what's going on in this PR:
  * Introduce a new DateAndTime struct, which just contains separate
  `Date` and `Time` fields, where the `time` field can support up to
  Nanosecond precision
  * For _prepared_ statement execution, we actually return a DateTime
  column for > millisecond precision, and there used to be no warning.
  We now emit a warning that precision is being lost and that
  `mysql_date_and_time=true` should be passed to avoid such loss
  * For _directly executed_ queries, we throw an InexactError and now
  emit the same warning that `mysql_date_and_time=true` should be passed
  to avoid such errors. We could perhaps match the prepare behavior and
  return `DateTime`, but I wanted to avoid changing too much all at once
  * Why introduce a keyword arg instead of just making it the default?
  Well, that'd be breaking. It's also tricky because we don't
  necessarily want to force this new `DateAndTime` struct on _all_
  DATETIME/TIMESTAMP columns, especially if their precision is within
  the millisecond range. i.e. it's much more convenient for users to
  work direclty with `DateTime` objects instead of this new
  `DateAndTime` struct. So the behavior now is: emit clear warnings in
  cases where DateTime can't handle the precision, and users can pass
  `mysql_date_and_time=true` and then handle `DateAndTime` objects
  accordingly.