### PR TITLE
Ignore any host url protocol that includes "mysql://"

### DIFF
--- a/src/MySQL.jl
+++ b/src/MySQL.jl
@@ -27,6 +27,10 @@ mutable struct Connection <: DBInterface.Connection
         API.setoption(mysql, API.MYSQL_SET_CHARSET_NAME, "utf8mb4")
         client_flag = clientflags(; kw...)
         setoptions!(mysql; kw...)
+        rng = findfirst("mysql://", host)
+        if rng !== nothing
+            host = host[last(rng)+1:end]
+        end
         mysql = API.connect(mysql, host, user, passwd, db, port, unix_socket, client_flag)
         return new(mysql, host, user, string(port), db, nothing)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,10 @@ using Test, MySQL, DBInterface, Tables, Dates, DecFP
 conn = DBInterface.connect(MySQL.Connection, "127.0.0.1", "root", ""; port=3306)
 DBInterface.close!(conn)
 
+# https://github.com/JuliaDatabases/MySQL.jl/issues/170
+conn = DBInterface.connect(MySQL.Connection, "mysql://127.0.0.1", "root", ""; port=3306)
+DBInterface.close!(conn)
+
 # load host/user + options from file
 conn = DBInterface.connect(MySQL.Connection, "", "", ""; option_file="my.ini")
 @test isopen(conn)


### PR DESCRIPTION
Fixes #170. As far as I can tell, certain projects suggest/require using
"mysql://", "mysqlx://", "jdbc:mysql://", etc. as the protocol portion
of the host url. This ends up with really weird behavior in MySQL.jl
because it assumes there's a plugin that needs to be loaded. So the fix
here is just a simple check if "mysql://" is in the host url and if so,
only use the rest of the string after it.