### PR TITLE
Fix issue loading Int8/UInt8 values into mysql table

### DIFF
--- a/src/MySQL.jl
+++ b/src/MySQL.jl
@@ -302,7 +302,7 @@ function DBInterface.close!(conn::Connection)
 end
 
 Base.close(conn::Connection) = DBInterface.close!(conn)
-Base.isopen(conn::Connection) = API.isopen(conn.mysql)
+Base.isopen(conn::Connection) = conn.mysql.ptr != C_NULL && API.isopen(conn.mysql)
 
 function juliatype(field_type, notnullable, isunsigned, isbinary, date_and_time)
     T = API.juliatype(field_type)

--- a/src/load.jl
+++ b/src/load.jl
@@ -69,6 +69,7 @@ function load end
 load(conn::Connection, table::AbstractString="mysql_"*Random.randstring(5); kw...) = x->load(x, conn, table; kw...)
 
 function load(itr, conn::Connection, name::AbstractString="mysql_"*Random.randstring(5); append::Bool=true, quoteidentifiers::Bool=true, debug::Bool=false, limit::Integer=typemax(Int64), kw...)
+    isopen(conn) || throw(ArgumentError("`MySQL.Connection` is closed"))
     # get data
     rows = Tables.rows(itr)
     sch = Tables.schema(rows)

--- a/src/prepare.jl
+++ b/src/prepare.jl
@@ -219,7 +219,7 @@ end
 
 inithelper!(helper, x::Union{Bool, UInt8, Int8}) = helper.uint8 = UInt8[Core.bitcast(UInt8, x)]
 ptrhelper(helper, x::Union{Bool, UInt8, Int8}) = pointer(helper.uint8)
-sethelper!(helper, x::Union{Bool, UInt8, Int8}) = helper.uint8[1] = Core.bitcast(Bool, x)
+sethelper!(helper, x::Union{Bool, UInt8, Int8}) = helper.uint8[1] = Core.bitcast(UInt8, x)
 getvalue(stmt, helper, values, i, ::Type{T}) where {T <: Union{Bool, UInt8, Int8}} = Core.bitcast(T, helper.uint8[1])
 
 inithelper!(helper, x::Union{UInt16, Int16}) = helper.uint16 = UInt16[Core.bitcast(UInt16, x)]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -331,7 +331,15 @@ DBInterface.execute(stmt, [SubString("foo")])
 # escaping AbstractString
 @test MySQL.escape(conn, SubString("'); DROP TABLE Employee; --")) == "\\'); DROP TABLE Employee; --"
 
+# https://github.com/JuliaDatabases/MySQL.jl/issues/194
+ct = (x = UInt8[1, 2, 3],)
+MySQL.load(ct, conn, "test194")
+ct2 = columntable(DBInterface.execute(conn, "select * from test194"))
+
 # 156
 res = DBInterface.execute(conn, "select * from Employee")
 DBInterface.close!(conn)
 ret = columntable(res)
+
+# load on closed connection should throw
+@test_throws ArgumentError MySQL.load(ct, conn, "test194")


### PR DESCRIPTION
Fixes https://github.com/JuliaDatabases/MySQL.jl/issues/194.

Basically just a typo in the core 1-byte loading code. We probably started out with treating `Bool` separately from Int8/UInt8 and then combined the code support, but forgot to change the bitcast to `UInt8` instead of `Bool`, which resulted in the "truncation" result shared in the original issue.