### PR TITLE
Ensure string options are converted to proper strings before passing …

### DIFF
--- a/src/api/capi.jl
+++ b/src/api/capi.jl
@@ -964,14 +964,20 @@ For more information about option files used by MySQL programs, see Section 4.2.
 function setoption(mysql::MYSQL, option::mysql_option, arg="0")
     if option in CUINTOPTS
         ref = Ref{Cuint}(Cuint(arg))
+        return @checksuccess mysql mysql_options(mysql.ptr, option, ref)
     elseif option in CULONGOPTS
         ref = Ref{Culong}(Culong(arg))
+        return @checksuccess mysql mysql_options(mysql.ptr, option, ref)
     elseif option in BOOLOPTS
         ref = Ref{Bool}(Bool(arg))
+        return @checksuccess mysql mysql_options(mysql.ptr, option, ref)
     else
-        ref = arg == C_NULL ? C_NULL : convert(Ptr{Cvoid}, pointer(arg))
+        str = arg == C_NULL ? C_NULL : String(arg)
+        GC.@preserve str begin
+            ref = str == C_NULL ? C_NULL : convert(Ptr{Cvoid}, pointer(str))
+            return @checksuccess mysql mysql_options(mysql.ptr, option, ref)
+        end
     end
-    return @checksuccess mysql mysql_options(mysql.ptr, option, ref)
 end
 
 #="""


### PR DESCRIPTION
…to ccall

Proper fix to #201. The core issue here is that if you take the `pointer` of a SubString, it doesn't properly account for the _substring_ length, because C strings continue until the NUL termination.