### PR TITLE
Allow binding Nothing to NULL

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MySQL"
 uuid = "39abe10b-433b-5dbd-92d4-e302a9df00cd"
 author = ["quinnj"]
-version = "1.4.3"
+version = "1.4.4"
 
 [deps]
 DBInterface = "a10d1c49-ce27-4219-8d33-6db1a4562965"

--- a/src/prepare.jl
+++ b/src/prepare.jl
@@ -312,7 +312,7 @@ function returnbind!(helper, binds, i, type, ::Type{T}) where {T}
     return
 end
 
-function bind!(helper, binds, i, x::Missing)
+function bind!(helper, binds, i, x::Union{Missing,Nothing})
     helper.is_null[1] = true
     return
 end


### PR DESCRIPTION
Allows using `nothing` to represent `NULL`.
Currently you must use `missing` to do this, and I think that is somewhat unintuitive.

Fixes #210
