### PR TITLE
Fix transaction() not actually using a transaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ deps/build.log
 
 # Manifest file
 Manifest.toml
+
+.vscode/

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MySQL"
 uuid = "39abe10b-433b-5dbd-92d4-e302a9df00cd"
 author = ["quinnj"]
-version = "1.4.3"
+version = "1.4.4"
 
 [deps]
 DBInterface = "a10d1c49-ce27-4219-8d33-6db1a4562965"

--- a/src/load.jl
+++ b/src/load.jl
@@ -105,14 +105,12 @@ function load(itr, conn::Connection, name::AbstractString="mysql_"*Random.randst
 end
 
 function transaction(f::Function, conn)
-    API.autocommit(conn.mysql, false)
+    execute(conn, "START TRANSACTION")
     try
         f()
         API.commit(conn.mysql)
     catch
         API.rollback(conn.mysql)
         rethrow()
-    finally
-        API.autocommit(conn.mysql, true)
     end
 end


### PR DESCRIPTION
`transaction()` used to just turn off autocommit, which means that rollback doesn't work:
```julia
julia> transaction(db) do
           stmt = prepare(db, "insert into foo (a) values (?);")
           execute(stmt, [6])
           error("force rollback")
       end
ERROR: force rollback
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] (::var"#1#2")()
   @ Main ./REPL[6]:4
 [3] transaction(f::var"#1#2", ::MySQL.Connection)
   @ DBInterface ~/.julia/packages/DBInterface/1Gmxx/src/DBInterface.jl:166
 [4] top-level scope
   @ REPL[6]:1

julia> DataFrame(execute(db, "select * from foo"))
6×1 DataFrame
 Row │ a      
     │ Int32? 
─────┼────────
   1 │      1
   2 │      1
   3 │      1
   4 │      2
   5 │      1
   6 │      6
```

I didn't find any C API for starting a transaction, so I am using the SQL instead. ref. https://dev.mysql.com/doc/c-api/8.0/en/c-api-basic-function-reference.html
