### PR TITLE
Escaping the error "Method overwriting is not permitted during Module precompilation" with Julia V 1.10

### DIFF
--- a/src/api/capi.jl
+++ b/src/api/capi.jl
@@ -431,15 +431,14 @@ Zero for success. Nonzero if an error occurred; this occurs for option values th
 """=#
 function getoption(mysql::MYSQL, option::mysql_option)
     if option in CUINTOPTS
-        arg = Ref{Cuint}()
+        return @checksuccess mysql mysql_get_option_Cuint(mysql.ptr, option, Ref{Cuint}())
     elseif option in CULONGOPTS
-        arg = Ref{Culong}()
+        return @checksuccess mysql mysql_get_option_Culong(mysql.ptr, option, Ref{Culong}())
     elseif option in BOOLOPTS
-        arg = Ref{Bool}()
+        return @checksuccess mysql mysql_get_option_Bool(mysql.ptr, option, Ref{Bool}())
     else
-        arg = Ref{String}()
+        return @checksuccess mysql mysql_get_option_String(mysql.ptr, option, Ref{String}())
     end
-    return @checksuccess mysql mysql_get_option(mysql.ptr, option, arg)
 end
 
 #="""

--- a/src/api/capi.jl
+++ b/src/api/capi.jl
@@ -963,18 +963,18 @@ For more information about option files used by MySQL programs, see Section 4.2.
 function setoption(mysql::MYSQL, option::mysql_option, arg="0")
     if option in CUINTOPTS
         ref = Ref{Cuint}(Cuint(arg))
-        return @checksuccess mysql mysql_options(mysql.ptr, option, ref)
+        return @checksuccess mysql mysql_options_Cuint(mysql.ptr, option, ref)
     elseif option in CULONGOPTS
         ref = Ref{Culong}(Culong(arg))
-        return @checksuccess mysql mysql_options(mysql.ptr, option, ref)
+        return @checksuccess mysql mysql_options_Culong(mysql.ptr, option, ref)
     elseif option in BOOLOPTS
         ref = Ref{Bool}(Bool(arg))
-        return @checksuccess mysql mysql_options(mysql.ptr, option, ref)
+        return @checksuccess mysql mysql_options_Bool(mysql.ptr, option, ref)
     else
         str = arg == C_NULL ? C_NULL : String(arg)
         GC.@preserve str begin
             ref = str == C_NULL ? C_NULL : convert(Ptr{Cvoid}, pointer(str))
-            return @checksuccess mysql mysql_options(mysql.ptr, option, ref)
+            return @checksuccess mysql mysql_options_Cvoid(mysql.ptr, option, ref)
         end
     end
 end

--- a/src/api/ccalls.jl
+++ b/src/api/ccalls.jl
@@ -215,28 +215,28 @@ function mysql_get_host_info(mysql::Ptr{Cvoid})
 end
 
 #int mysql_get_option(MYSQL *mysql, enum mysql_option option, const void *arg)
-function mysql_get_option(mysql::Ptr{Cvoid}, option::Integer, arg::Ref{Cuint})
+function mysql_get_option_Cuint(mysql::Ptr{Cvoid}, option::Integer, arg::Ref{Cuint})
     return @c(:mysql_get_option,
                 Cint,
                 (Ptr{Cvoid}, Cint, Ref{Cuint}),
                 mysql, option, arg)
 end
 
-function mysql_get_option(mysql::Ptr{Cvoid}, option::Integer, arg::Ref{Culong})
+function mysql_get_option_Culong(mysql::Ptr{Cvoid}, option::Integer, arg::Ref{Culong})
     return @c(:mysql_get_option,
                 Cint,
                 (Ptr{Cvoid}, Cint, Ref{Culong}),
                 mysql, option, arg)
 end
 
-function mysql_get_option(mysql::Ptr{Cvoid}, option::Integer, arg::Ref{Bool})
+function mysql_get_option_Bool(mysql::Ptr{Cvoid}, option::Integer, arg::Ref{Bool})
     return @c(:mysql_get_option,
                 Cint,
                 (Ptr{Cvoid}, Cint, Ref{Bool}),
                 mysql, option, arg)
 end
 
-function mysql_get_option(mysql::Ptr{Cvoid}, option::Integer, arg::Ptr{Cvoid})
+function mysql_get_option_Cvoid(mysql::Ptr{Cvoid}, option::Integer, arg::Ptr{Cvoid})
     return @c(:mysql_get_option,
                 Cint,
                 (Ptr{Cvoid}, Cint, Ptr{Cvoid}),

--- a/src/api/ccalls.jl
+++ b/src/api/ccalls.jl
@@ -338,28 +338,28 @@ function mysql_num_rows(results::Ptr{Cvoid})
 end
 
 #int mysql_options(MYSQL *mysql, enum mysql_option option, const void *arg)
-function mysql_options(mysql::Ptr{Cvoid}, option::mysql_option, arg::Ref{Cuint})
+function mysql_options_Cuint(mysql::Ptr{Cvoid}, option::mysql_option, arg::Ref{Cuint})
     return @c(:mysql_options,
                 Cint,
                 (Ptr{Cvoid}, Cint, Ref{Cuint}),
                 mysql, option, arg)
 end
 
-function mysql_options(mysql::Ptr{Cvoid}, option::mysql_option, arg::Ref{Culong})
+function mysql_options_Culong(mysql::Ptr{Cvoid}, option::mysql_option, arg::Ref{Culong})
     return @c(:mysql_options,
                 Cint,
                 (Ptr{Cvoid}, Cint, Ref{Culong}),
                 mysql, option, arg)
 end
 
-function mysql_options(mysql::Ptr{Cvoid}, option::mysql_option, arg::Ref{Bool})
+function mysql_options_Bool(mysql::Ptr{Cvoid}, option::mysql_option, arg::Ref{Bool})
     return @c(:mysql_options,
                 Cint,
                 (Ptr{Cvoid}, Cint, Ref{Bool}),
                 mysql, option, arg)
 end
 
-function mysql_options(mysql::Ptr{Cvoid}, option::mysql_option, arg::Ptr{Cvoid})
+function mysql_options_Cvoid(mysql::Ptr{Cvoid}, option::mysql_option, arg::Ptr{Cvoid})
     return @c(:mysql_options,
                 Cint,
                 (Ptr{Cvoid}, Cint, Ptr{Cvoid}),


### PR DESCRIPTION
Hello,

This litte PR to avoid the anoying error "Method overwriting ..." error each time you want to use the module

Not very clean but very low footprint and should not break anything.

For beta tester, you could use my repo in place of the official : https://github.com/pascalr0410/MySQL.jl.git

Regards,

Pascal.