### PR TITLE
Compat Upgrade of MariaDB_Connector_C_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 DBInterface = "2.5"
 DecFP = "0.4.9, 0.4.10, 1"
-MariaDB_Connector_C_jll = "=3.1.12"
+MariaDB_Connector_C_jll = "3.1.12"
 Parsers = "0.3, 1, 2"
 Tables = "1"
 julia = "1.6"


### PR DESCRIPTION
Simply trying to remove the restricting compat.

Please let me know what the original reason for this quite restrictive compat has been. I am sure there is actually a good reason.

Resolves #221 