### PR TITLE
Fix trim compilation on Julia 1.13

### DIFF
--- a/src/connect.jl
+++ b/src/connect.jl
@@ -104,7 +104,9 @@ function resolve_bind(
     TRIM_CALL_EDGE[] && work()
     task = Task(work)
     task.sticky = false
-    errormonitor(task)
+    # BindResolve returns resolver errors through result; wait(task) below also
+    # propagates task failures. Base.errormonitor adds a dynamic error-display
+    # task that cannot be compiled with --trim=safe on Julia 1.13.
     schedule(task)
     left = deadline - Int64(time_ns())
     left > 0 || throw(P.TimeoutError(timeout_message))
@@ -200,7 +202,9 @@ end
 # statically resolvable.
 @inline server_error_text(e::P.ServerError) = return e isa P.StmtError ? sprint(showerror, e) : sprint(showerror, e::P.Error)
 
-@inline function throw_with_server_cause(err, cause::P.ServerError)
+# A caught user exception has type Any. Keep one callable specialization for it,
+# so trim compilation need not resolve dispatch on the user's exception type.
+@noinline function throw_with_server_cause(@nospecialize(err), cause::P.ServerError)
     try
         throw(cause)
     catch

--- a/src/reaper.jl
+++ b/src/reaper.jl
@@ -160,7 +160,8 @@ function ensure_reaper!()
         end
         task = Task(reaper_loop)
         task.sticky = false
-        errormonitor(task)
+        # reaper_loop handles timer shutdown and logs reclamation errors itself.
+        # Base.errormonitor would add an untrimmable dynamic error-display task.
         schedule(task)
         atexit(reaper_atexit)
     finally

--- a/test/protocol/native_tests.jl
+++ b/test/protocol/native_tests.jl
@@ -327,6 +327,17 @@ end
     warm_deadline = Int64(time_ns()) + 5_000_000_000
     @test N.resolve_bind("bind.example", warm_deadline, resolver) == [Reseau.TCP.loopback_addr(0)]
     @test take!(called_with) == ("tcp", "bind.example:0")
+    # Resolver errors travel through BindResolveOutcome and retain their identity
+    # without a separate errormonitor task.
+    resolver_error = ErrorException("bind resolver failed")
+    failing_resolver = (network, address) -> throw(resolver_error)
+    caught = try
+        N.resolve_bind("bind.example", Int64(time_ns()) + 5_000_000_000, failing_resolver)
+        nothing
+    catch ex
+        ex
+    end
+    @test caught === resolver_error
     block_resolver[] = true
     before = Int64(time_ns())
     err = try


### PR DESCRIPTION
The scheduled performance job started failing when the latest stable Julia changed from 1.12.7 to 1.13.0 after the 2.0 release. Both September 10 and 11 runs passed fuzzing and all performance gates, but failed trim compilation with nine errors and four warnings.

Keep a non-specialized, non-inlined exception helper so caught user exceptions retain a statically callable path and the server exception chain. Remove redundant `errormonitor` tasks from the bind resolver and reaper: the resolver returns errors through its result channel, and the reaper handles timer shutdown and logs reclamation errors itself. Julia 1.13 traces the monitor's dynamic error-display code, which cannot pass strict trim verification.

Validation:
- Reproduced the exact nine errors and four warnings on Julia 1.13.0 before the fix.
- The exception-helper change alone reduced this to nine errors and zero warnings.
- The full fix passes all eight strict trim compile/executable checks on Julia 1.13.0 and 1.12.7.
- Julia 1.13.0 serverless suite: 1,846/1,846 checks passed, including exception chaining, resolver timeouts, reaper cleanup, and the new resolver-error identity check.
- No trim budgets, performance limits, or workflow skips were relaxed.
- [PR CI](https://github.com/JuliaDatabases/MySQL.jl/actions/runs/34634104996): all 13 applicable jobs passed.
- [Manual CI including scheduled jobs](https://github.com/JuliaDatabases/MySQL.jl/actions/runs/34634134157): all 15 jobs passed. The performance job passed 1,874 checks; fuzzing completed 11.9 million cases with zero findings.
- The manual macOS development-Julia job initially hit a Reseau socket-write error in the large-packet test. The same job passed in PR CI, 100 local packet-test repetitions passed, and the failed job passed on retry without code changes. This separate intermittent error was not reproduced locally.

Failing runs: https://github.com/JuliaDatabases/MySQL.jl/actions/runs/34470714085 and https://github.com/JuliaDatabases/MySQL.jl/actions/runs/34593589504.

Co-authored by Codex
